### PR TITLE
Olympian age endpoints

### DIFF
--- a/app/controllers/api/v1/olympians_controller.rb
+++ b/app/controllers/api/v1/olympians_controller.rb
@@ -1,5 +1,9 @@
 class Api::V1::OlympiansController < ApplicationController
   def index
-    @olympians = Olympian.all
+    if params[:age]
+      @olympian = Olympian.request_age(params[:age])
+    else
+      @olympians = Olympian.all
+    end
   end
 end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -5,6 +5,15 @@ class Olympian < ApplicationRecord
   has_many :olympics, through: :results
   has_many :events, through: :results
 
+  def self.request_age(request)
+    case request
+    when 'youngest'
+      order('age ASC').take
+    when 'oldest'
+      order('age DESC').take
+    end
+  end
+
   def sport
     sport_id = self.events.first.sport_id
     Sport.find_by(id: sport_id).name

--- a/app/views/api/v1/olympians/index.json.jbuilder
+++ b/app/views/api/v1/olympians/index.json.jbuilder
@@ -1,1 +1,2 @@
-json.olympians @olympians, :name, :team, :age, :sport, :total_medals_won
+json.olympians @olympians, :name, :team, :age, :sport, :total_medals_won if @olympians
+json.(@olympian, :name, :team, :age, :sport, :total_medals_won) if @olympian

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -1,6 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe Olympian, type: :model do
+  before :each do
+    @olympian_1 = Olympian.create!(name: 'Andreea Aanei', sex: 'F', age: '22', height: '170', weight: '125', team: 'Romania')
+    @olympian_2 = Olympian.create!(name: 'Samy Abdel Razek', sex: 'F', age: '36', height: '170', weight: '60', team: 'Egypt')
+    @olympic = Olympic.create!(games: '2016 Summer')
+    @sport_1 = Sport.create!(name: 'Weightlifting')
+    @sport_2 = Sport.create!(name: 'Shooting')
+    @event_1 = Event.create!(name: "Weightlifting Women's Super-Heavyweight", sport: @sport_1)
+    @event_2 = Event.create!(name: "Shooting Women's Air Rifle, 10 metres", sport: @sport_2)
+    @result_1 = Result.create!(medal: 'NA', olympian: @olympian_1, event: @event_1, olympic: @olympic)
+    @result_2 = Result.create!(medal: 'NA', olympian: @olympian_2, event: @event_2, olympic: @olympic)
+  end
+
   describe 'validations' do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:age) }
@@ -16,25 +28,24 @@ RSpec.describe Olympian, type: :model do
     it { should have_many(:events).through(:results) }
   end
 
-  describe 'instance methods' do
-    before :each do
-      @olympian = Olympian.create!(name: 'Andreea Aanei', sex: 'F', age: '22', height: '170', weight: '125', team: 'Romania')
-      @olympic = Olympic.create!(games: '2016 Summer')
-      @sport = Sport.create!(name: 'Weightlifting')
-      @event = Event.create!(name: "Weightlifting Women's Super-Heavyweight", sport: @sport)
-      @result = Result.create!(medal: 'NA', olympian: @olympian, event: @event, olympic: @olympic)
+  describe 'class methods' do
+    it 'request_age(request)' do
+      expect(Olympian.request_age('youngest')).to eq(@olympian_1)
+      expect(Olympian.request_age('oldest')).to eq(@olympian_2)
     end
+  end
 
+  describe 'instance methods' do
     it 'sport' do
-      expect(@olympian.sport).to eq(@sport.name)
+      expect(@olympian_1.sport).to eq(@sport_1.name)
     end
 
     it 'total_medals_won' do
-      expect(@olympian.total_medals_won).to eq(0)
+      expect(@olympian_1.total_medals_won).to eq(0)
 
-      @result.update(medal: 'Gold')
+      @result_1.update(medal: 'Gold')
 
-      expect(@olympian.total_medals_won).to eq(1)
+      expect(@olympian_1.total_medals_won).to eq(1)
     end
   end
 end

--- a/spec/requests/api/v1/olympians/request_age_olympian_spec.rb
+++ b/spec/requests/api/v1/olympians/request_age_olympian_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+require 'csv'
+
+describe 'Youngest Olympian', type: :request do
+
+  before :all do
+    CSV.foreach('./spec/data/sample_olympic_data_2016.csv', headers: true, header_converters: :symbol) do |row|
+      olympian = Olympian.find_or_create_by!(row.to_hash.except(:games, :sport, :event, :medal))
+      olympic = Olympic.find_or_create_by!(games: row[:games])
+      sport = Sport.find_or_create_by!(name: row[:sport])
+      event = Event.find_or_create_by!(name: row[:event], sport_id: sport.id)
+      Result.find_or_create_by!(medal: row[:medal], olympian_id: olympian.id, event_id: event.id, olympic_id: olympic.id)
+    end
+
+    @content_type = {'Content-Type': 'application/json', 'Accept': 'application/json'}
+  end
+
+  it 'returns json information of the youngest olympian' do
+    get '/api/v1/olympians?age=youngest', headers: @content_type
+
+    expect(response).to have_http_status(:successful)
+
+    result = JSON.parse(response.body)
+
+    olympian = Olympian.request_age('youngest')
+
+    # Check response correct format
+    expect(result).to have_key('name')
+    expect(result).to have_key('team')
+    expect(result).to have_key('age')
+    expect(result).to have_key('sport')
+    expect(result).to have_key('total_medals_won')
+    # Check response correct values
+    expect(result['name']).to eq(olympian.name)
+    expect(result['team']).to eq(olympian.team)
+    expect(result['age']).to eq(olympian.age)
+    expect(result['sport']).to eq(olympian.sport)
+    expect(result['total_medals_won']).to eq(olympian.total_medals_won)
+  end
+
+  it 'returns json information of the oldest olympian' do
+    get '/api/v1/olympians?age=oldest', headers: @content_type
+
+    expect(response).to have_http_status(:successful)
+
+    result = JSON.parse(response.body)
+
+    olympian = Olympian.request_age('oldest')
+
+    # Check response correct format
+    expect(result).to have_key('name')
+    expect(result).to have_key('team')
+    expect(result).to have_key('age')
+    expect(result).to have_key('sport')
+    expect(result).to have_key('total_medals_won')
+    # Check response correct values
+    expect(result['name']).to eq(olympian.name)
+    expect(result['team']).to eq(olympian.team)
+    expect(result['age']).to eq(olympian.age)
+    expect(result['sport']).to eq(olympian.sport)
+    expect(result['total_medals_won']).to eq(olympian.total_medals_won)
+  end
+end


### PR DESCRIPTION
## Changes proposed in this pull request:
* Add class method request_age(request) to determine youngest or oldest olympian with spec
* Add youngest or oldest olympian endpoint specs
* Update OlympianController and index template to display oldest or youngest olympian

## Card(s) closed in this pull request:
close #7 
close #8 

## What did you struggle on to complete?
* I couldn't use Jbuilder to put oldest or youngest olympian in an array.

## Current Test Suite:
### Test Coverage Percentage: 100%
- [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
- [x] Checked coverage/index.html - did not add any new code that's not covered by testing (if possible)
- [x] Ran the test suite - all tests are passing
- [x] Merged in the latest master to my branch with git pull origin master & resolved merge conflicts
- [x] I have commented my code, particularly in hard-to-understand areas

## Helpful Resources:
* [Ruby case statements](https://www.rubyguides.com/2015/10/ruby-case/)
