### PR TITLE
Add splash landing page for app

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,6 @@ Rails.application.routes.draw do
       resources :olympians, only: [:index]
     end
   end
+
+  get '*other', to: redirect('/')
 end

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,3 @@
+<h1>Welcome to Korobibos API</h1>
+
+<p>Go [here](https://github.com/lpile/koroibos-api) for endpoint documentation</p>


### PR DESCRIPTION
## Changes proposed in this pull request:
* Add landing page to redirect users to endpoint documentation.

## Card(s) closed in this pull request:
close #24 

## What did you struggle on to complete?
* I've tried to clean up a n+1 query but I could not figure it out. I'll try again later.

## Current Test Suite:
### Test Coverage Percentage: 100%
- [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
- [x] Checked coverage/index.html - did not add any new code that's not covered by testing (if possible)
- [x] Ran the test suite - all tests are passing
- [x] Merged in the latest master to my branch with git pull origin master & resolved merge conflicts
- [x] I have commented my code, particularly in hard-to-understand areas

## Helpful Resources:
* [Homepage for rails api](https://stackoverflow.com/questions/38366501/rails-5-api-only-app-with-home-page)
